### PR TITLE
Prevent empty oneOf types

### DIFF
--- a/src/validate-schema.js
+++ b/src/validate-schema.js
@@ -71,7 +71,16 @@ export default ({ extensions, schema }) => {
         object: {
           ...extensions?.oneOf,
           ...shared,
-          oneOf: typeObject,
+          oneOf: {
+            type: typeObject,
+            validate: ({ path, value }) => {
+              if (!Object.keys(value).length) {
+                throw new Error(`Expected one of type at ${JSON.stringify(path)} to have at least one type`);
+              }
+
+              return value;
+            }
+          },
           resolveType: fn
         }
       },

--- a/src/validate-schema.test.js
+++ b/src/validate-schema.test.js
@@ -1,0 +1,11 @@
+import { strict as assert } from 'assert';
+
+import validateSchema from './validate-schema.js';
+
+export default () => {
+  assert.throws(
+    () => validateSchema({
+      schema: { emptyOneOf: { oneOf: {}, resolveType: () => {} } }
+    })
+  );
+};


### PR DESCRIPTION
The current behavior is to return -Infinity due to the return for Math.max when not provided any values, which feels like unexpected behavior. The change here is to return a cost of 0 for an empty oneOf, but perhaps you'd prefer to add validation to ensure a oneOf has at least one possible value instead. As it stands, given that an empty oneOf is a valid type, it should be costed accurately.